### PR TITLE
Fix joining room and unknown sender

### DIFF
--- a/line/client.py
+++ b/line/client.py
@@ -533,6 +533,13 @@ class LineClient(LineAPI):
                                 sender = m
                                 break
 
+                    # If sender is not found, check member list of room chat sent to
+                    if sender is None and type(receiver) is LineRoom:
+                        for m in receiver.contacts:
+                            if m.id == raw_sender:
+                                sender = m
+                                break
+
                     if sender is None or receiver is None:
                         self.refreshGroups()
                         self.refreshContacts()

--- a/line/client.py
+++ b/line/client.py
@@ -549,6 +549,8 @@ class LineClient(LineAPI):
                                 receiver = LineContact(self, contacts[1])
 
                     yield (sender, receiver, message)
+                elif operation.type in [ 60, 61 ]:
+                    pass
                 else:
                     print "[*] %s" % OT._VALUES_TO_NAMES[operation.type]
                     print operation


### PR DESCRIPTION
I found that operation type 60 and 61 appear when asking someone to join a room and leave a room.
Operation type 60 appears at the same time as INVITE_INTO_ROOM(21) and 61 appears at the same time as NOTIFIED_LEAVE_ROOM(24). I don't know what they are though.
Anyway, when either appears, it makes longPoll() keep raising KeyError 60 or 61 because they are not defined in curve.ttype and the polling just stops. 
Must kill and start the process again.

Once joined, sender was None if that member is not in your contact list. 